### PR TITLE
Provides classes for new "connect" and "scale" installers. Fixes #2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 ---
+before_install:
+  - gem update --system
 script: "./script/cibuild"
 gemfile: "this/does/not/exist"
 rvm:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Install the [Fitbit](http://www.fitbit.com) fitness tracker.
 
 ## Usage
 
+* `include fitbit` - Alias for `fitbit::ultra` for backward compatibility with release 1.0.0
 * `include fitbit::aria` - Install the Fitbit Aria scale connector
 * `include fitbit::force` - Install the connector for Fitbit Force
 * `include fitbit::flex` - Install the connector for Fitbit Flex
@@ -14,7 +15,6 @@ Install the [Fitbit](http://www.fitbit.com) fitness tracker.
 * `include fitbit::connect` - Generic connector for Fitbit Force, Flex, One, or Zip
 * `include fitbit::ultra` - Install the connector for Fitbit Ultra
 * `include fitbit::scale` - Alias for `fitbit::aria`
-* `include fitbit` - Alias for `fitbit::ultra` for backward compatibility with release 1.0.0
 
 ## Required Puppet Modules
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ Install the [Fitbit](http://www.fitbit.com) fitness tracker.
 
 ## Usage
 
-```puppet
-include fitbit
-```
+* `include fitbit::aria` - Install the Fitbit Aria scale connector
+* `include fitbit::force` - Install the connector for Fitbit Force
+* `include fitbit::flex` - Install the connector for Fitbit Flex
+* `include fitbit::one` - Install the connector for Fitbit One
+* `include fitbit::zip` - Install the connector for Fitbit Zip
+* `include fitbit::connect` - Generic connector for Fitbit Force, Flex, One, or Zip
+* `include fitbit::ultra` - Install the connector for Fitbit Ultra
+* `include fitbit::scale` - Alias for `fitbit::aria`
+* `include fitbit` - Alias for `fitbit::ultra` for backward compatibility with release 1.0.0
 
 ## Required Puppet Modules
 

--- a/manifests/aria.pp
+++ b/manifests/aria.pp
@@ -6,6 +6,6 @@
 class fitbit::aria {
   package { 'FitbitScale':
     provider => 'pkgdmg',
-    source   => "http://cache.fitbit.com/scaleSetup/FitbitScaleSetup_Mac_20121127_1.0.0.86.dmg"
+    source   => 'http://cache.fitbit.com/scaleSetup/FitbitScaleSetup_Mac_20121127_1.0.0.86.dmg'
   }
 }

--- a/manifests/aria.pp
+++ b/manifests/aria.pp
@@ -1,0 +1,11 @@
+# Public: Install Fitbit sync software.
+#
+# Examples
+#
+#   include fitbit::aria
+class fitbit::aria {
+  package { 'FitbitScale':
+    provider => 'pkgdmg',
+    source   => "http://cache.fitbit.com/scaleSetup/FitbitScaleSetup_Mac_20121127_1.0.0.86.dmg"
+  }
+}

--- a/manifests/connect.pp
+++ b/manifests/connect.pp
@@ -6,6 +6,6 @@
 class fitbit::connect {
   package { 'FitbitConnect':
     provider => 'pkgdmg',
-    source   => "http://cache.fitbit.com/FitbitConnect/FitbitConnect_Mac_20130926_1.0.0.4012.dmg"
+    source   => 'http://cache.fitbit.com/FitbitConnect/FitbitConnect_Mac_20130926_1.0.0.4012.dmg'
   }
 }

--- a/manifests/connect.pp
+++ b/manifests/connect.pp
@@ -1,0 +1,11 @@
+# Public: Install Fitbit sync software.
+#
+# Examples
+#
+#   include fitbit::connect
+class fitbit::connect {
+  package { 'FitbitConnect':
+    provider => 'pkgdmg',
+    source   => "http://cache.fitbit.com/FitbitConnect/FitbitConnect_Mac_20130926_1.0.0.4012.dmg"
+  }
+}

--- a/manifests/flex.pp
+++ b/manifests/flex.pp
@@ -1,0 +1,8 @@
+# Public: Install Fitbit sync software.
+#
+# Examples
+#
+#   include fitbit::flex
+class fitbit::flex {
+  require fitbit::connect
+}

--- a/manifests/force.pp
+++ b/manifests/force.pp
@@ -1,0 +1,8 @@
+# Public: Install Fitbit sync software.
+#
+# Examples
+#
+#   include fitbit::force
+class fitbit::force {
+  require fitbit::connect
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,8 +4,5 @@
 #
 #   include fitbit
 class fitbit {
-  package { 'Fitbit':
-    provider => 'pkgdmg',
-    source   => 'http://cache.fitbit.com/uploader/Install_Fitbit-1.8.2.10.dmg'
-  }
+  require fitbit::ultra
 }

--- a/manifests/one.pp
+++ b/manifests/one.pp
@@ -1,0 +1,8 @@
+# Public: Install Fitbit sync software.
+#
+# Examples
+#
+#   include fitbit::one
+class fitbit::one {
+  require fitbit::connect
+}

--- a/manifests/scale.pp
+++ b/manifests/scale.pp
@@ -1,0 +1,8 @@
+# Public: Install Fitbit sync software.
+#
+# Examples
+#
+#   include fitbit::scale
+class fitbit::scale {
+  require fitbit::aria
+}

--- a/manifests/ultra.pp
+++ b/manifests/ultra.pp
@@ -1,0 +1,11 @@
+# Public: Install Fitbit sync software.
+#
+# Examples
+#
+#   include fitbit::ultra
+class fitbit::ultra {
+  package { 'Fitbit':
+    provider => 'pkgdmg',
+    source   => 'http://cache.fitbit.com/uploader/Install_Fitbit-1.8.2.10.dmg'
+  }
+}

--- a/manifests/zip.pp
+++ b/manifests/zip.pp
@@ -1,0 +1,8 @@
+# Public: Install Fitbit sync software.
+#
+# Examples
+#
+#   include fitbit::zip
+class fitbit::zip {
+  require fitbit::connect
+}

--- a/spec/classes/aria_spec.rb
+++ b/spec/classes/aria_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'fitbit::aria' do
+  it do
+    should contain_package('FitbitScale').with({
+      :provider => 'pkgdmg',
+      :source   => 'http://cache.fitbit.com/scaleSetup/FitbitScaleSetup_Mac_20121127_1.0.0.86.dmg'
+    })
+  end
+end

--- a/spec/classes/connect_spec.rb
+++ b/spec/classes/connect_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'fitbit::connect' do
+  it do
+    should contain_package('FitbitConnect').with({
+      :provider => 'pkgdmg',
+      :source   => 'http://cache.fitbit.com/FitbitConnect/FitbitConnect_Mac_20130926_1.0.0.4012.dmg',
+    })
+  end
+end

--- a/spec/classes/flex_spec.rb
+++ b/spec/classes/flex_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'fitbit::flex' do
+  it do
+    should contain_package('FitbitConnect').with({
+      :provider => 'pkgdmg',
+      :source   => 'http://cache.fitbit.com/FitbitConnect/FitbitConnect_Mac_20130926_1.0.0.4012.dmg',
+    })
+  end
+end

--- a/spec/classes/force_spec.rb
+++ b/spec/classes/force_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'fitbit::force' do
+  it do
+    should contain_package('FitbitConnect').with({
+      :provider => 'pkgdmg',
+      :source   => 'http://cache.fitbit.com/FitbitConnect/FitbitConnect_Mac_20130926_1.0.0.4012.dmg',
+    })
+  end
+end

--- a/spec/classes/one_spec.rb
+++ b/spec/classes/one_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'fitbit::one' do
+  it do
+    should contain_package('FitbitConnect').with({
+      :provider => 'pkgdmg',
+      :source   => 'http://cache.fitbit.com/FitbitConnect/FitbitConnect_Mac_20130926_1.0.0.4012.dmg',
+    })
+  end
+end

--- a/spec/classes/scale_spec.rb
+++ b/spec/classes/scale_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'fitbit::scale' do
+  it do
+    should contain_package('FitbitScale').with({
+      :provider => 'pkgdmg',
+      :source   => 'http://cache.fitbit.com/scaleSetup/FitbitScaleSetup_Mac_20121127_1.0.0.86.dmg'
+    })
+  end
+end

--- a/spec/classes/ultra_spec.rb
+++ b/spec/classes/ultra_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'fitbit::ultra' do
+  it do
+    should contain_package('Fitbit').with({
+      :provider => 'pkgdmg',
+      :source   => 'http://cache.fitbit.com/uploader/Install_Fitbit-1.8.2.10.dmg',
+    })
+  end
+end

--- a/spec/classes/zip_spec.rb
+++ b/spec/classes/zip_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'fitbit::zip' do
+  it do
+    should contain_package('FitbitConnect').with({
+      :provider => 'pkgdmg',
+      :source   => 'http://cache.fitbit.com/FitbitConnect/FitbitConnect_Mac_20130926_1.0.0.4012.dmg',
+    })
+  end
+end


### PR DESCRIPTION
This provides classes to setup various devices and should solve issue #2. For backward compatibility with older versions of `puppet-fitbit` specifying `include fitbit` will still setup the installer for the Fitbit Ultra. Also added some aliases for consistency.

I'm neither a ruby nor puppet expert, so i'm not entirely certain if the spec classes I've added are sufficient for testing (guidance welcome). I can say that `include fitbit::force` successfully included the "Fitbit Connect.app" for me.

Perhaps @mxie and @sporkd could test and report back?
